### PR TITLE
Improvements of MZP image.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 extract and reinject files into Witch of the Holy Night (Steam)
 
 
-Requires python >= 3.10, `numpy`, `Pillow`, `zlib`.
+Requires python >= 3.11, `numpy`, `Pillow`, `zlib`.
 `imagequant` is necessary on some ciconstances to quantize some images before
 injection.
 

--- a/hep.py
+++ b/hep.py
@@ -66,7 +66,18 @@ def hep_insert_tile(mzp: "MzpImage", tile_index: int, pixels: np.ndarray, compre
     
     pixels = pixels.reshape((mzp.tile_width, mzp.tile_height, 4))
 
-    indices, palette = quantize(pixels)
+    # Calculate edge_flags based on tile_index, tile_x_count, and tile_y_count
+    row = tile_index // mzp.tile_x_count
+    col = tile_index % mzp.tile_x_count
+    edge_flags = {
+        "left": col == 0,
+        "right": col == mzp.tile_x_count - 1,
+        "top": row == 0,
+        "bottom": row == mzp.tile_y_count - 1
+    }
+
+    # Quantize the tile with edge_flags
+    indices, palette = quantize(pixels, edge_flags=edge_flags)
     indices = np.uint8(indices)
     #palette = palette.astype(np.uint8)
 


### PR DESCRIPTION
Restored image edges when assembling from overlapping tiles.
Restored right and bottom edges for palette images.
Edge tiles maintain their outer edge when splitting the image into tiles.
Tile transparency considers the replacement of edges with transparent areas.
Defined fill color for tile areas extending beyond palette image boundaries.
Removed replacement of transparent black with (71, 112, 76, 0) (0x47, 0x70, 0x4C, 0x00) in quantization.
Added importance map to quantization for better palette preservation.
Access to archive entry keys has been added.
Error handling has been added for file injection into the archive.